### PR TITLE
switch to new package CapAndHomalg

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,5 +1,5 @@
 [deps]
-HomalgProject = "50bd374c-87b5-11e9-015a-2febe71398bd"
+CapAndHomalg = "c4774649-1891-41ea-a883-87141804c57c"
 IJulia = "7073ff75-c697-5162-941a-fcdaad2a7d2a"
 
 [compat]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This software provides a [Julia](https://julialang.org/) front-end for Adelman c
 
 Download the repository and execute the file `src/Adelman.jl` in Julia.
 
-Note that this software depends on the Julia package [HomalgProject](https://github.com/homalg-project/HomalgProject.jl) which in turn depends on the computer algebra system [OSCAR](https://oscar.computeralgebra.de/).
+Note that this software depends on the Julia package [CapAndHomalg](https://github.com/homalg-project/CapAndHomalg.jl) which in turn depends on the computer algebra system [OSCAR](https://oscar.computeralgebra.de/).
 
 ## Run the notebooks interactively in your browser
 

--- a/src/Adelman.jl
+++ b/src/Adelman.jl
@@ -7,7 +7,7 @@ module CAP
 
 export GAP
 
-using HomalgProject
+using CapAndHomalg
 GAP.LoadPackageAndExposeGlobals( "FreydCategoriesForCAP", CAP, all_globals = true )
 
 end # module CAP

--- a/worksheets/Basics.ipynb
+++ b/worksheets/Basics.ipynb
@@ -30,16 +30,9 @@
       "             Sophus 1.24, SpinSym 1.5.2, TomLib 1.2.9, TransGrp 2.0.5, \n",
       "             utils 0.69\n",
       " Try '??help' for help. See also '?copyright', '?cite' and '?authors'\n",
-      "Singular.jl, based on\n",
-      "                     SINGULAR                                 /  \n",
-      " A Computer Algebra System for Polynomial Computations       /  Singular.jl: 0.4.1 \n",
-      "                                                           0<   Singular   : 2.3.1-4\n",
-      " by: W. Decker, G.-M. Greuel, G. Pfister, H. Schoenemann     \\   \n",
-      "FB Mathematik der Universitaet, D-67653 Kaiserslautern        \\\n",
-      "     \n",
-      "HomalgProject v\u001b[32m0.5.2\u001b[39m\n",
-      "Imported OSCAR's components GAP, Nemo, and Singular\n",
-      "Type: ?HomalgProject for more information\n"
+      "CapAndHomalg v\u001b[32m1.0.0\u001b[39m\n",
+      "Imported OSCAR's components GAP and Singular_jll\n",
+      "Type: ?CapAndHomalg for more information\n"
      ]
     },
     {

--- a/worksheets/SnakeLemma.ipynb
+++ b/worksheets/SnakeLemma.ipynb
@@ -32,16 +32,9 @@
       "             Sophus 1.24, SpinSym 1.5.2, TomLib 1.2.9, TransGrp 2.0.5, \n",
       "             utils 0.69\n",
       " Try '??help' for help. See also '?copyright', '?cite' and '?authors'\n",
-      "Singular.jl, based on\n",
-      "                     SINGULAR                                 /  \n",
-      " A Computer Algebra System for Polynomial Computations       /  Singular.jl: 0.4.1 \n",
-      "                                                           0<   Singular   : 2.3.1-4\n",
-      " by: W. Decker, G.-M. Greuel, G. Pfister, H. Schoenemann     \\   \n",
-      "FB Mathematik der Universitaet, D-67653 Kaiserslautern        \\\n",
-      "     \n",
-      "HomalgProject v\u001b[32m0.5.2\u001b[39m\n",
-      "Imported OSCAR's components GAP, Nemo, and Singular\n",
-      "Type: ?HomalgProject for more information\n"
+      "CapAndHomalg v\u001b[32m1.0.0\u001b[39m\n",
+      "Imported OSCAR's components GAP and Singular_jll\n",
+      "Type: ?CapAndHomalg for more information\n"
      ]
     },
     {


### PR DESCRIPTION
CapAndHomalg loads much faster since it only depends
on Singular_jll.jl and not on Singular.jl

The tests will fail now but should succeed when the package is registered in [three days](https://github.com/JuliaRegistries/General/pull/23185#issuecomment-711287366). Please wait until then, retrigger the tests and then merge if you accept the PR.